### PR TITLE
Standardized Exit Codes

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/dictionaries/AndrielChaoti.xml
+++ b/.idea/dictionaries/AndrielChaoti.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="AndrielChaoti" />
+</component>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
@@ -10,7 +7,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="Oracle JDK 1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/github/vaerys/channelsettings/InitChannels.java
+++ b/src/main/java/com/github/vaerys/channelsettings/InitChannels.java
@@ -2,7 +2,7 @@ package com.github.vaerys.channelsettings;
 
 import com.github.vaerys.channelsettings.settings.*;
 import com.github.vaerys.channelsettings.types.*;
-import com.github.vaerys.main.Globals;
+import com.github.vaerys.main.Constants;
 import com.github.vaerys.templates.ChannelSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +50,7 @@ public class InitChannels {
             String errorReport = s.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(Globals.EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
         }
     }

--- a/src/main/java/com/github/vaerys/channelsettings/InitChannels.java
+++ b/src/main/java/com/github/vaerys/channelsettings/InitChannels.java
@@ -2,6 +2,7 @@ package com.github.vaerys.channelsettings;
 
 import com.github.vaerys.channelsettings.settings.*;
 import com.github.vaerys.channelsettings.types.*;
+import com.github.vaerys.main.Globals;
 import com.github.vaerys.templates.ChannelSetting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public class InitChannels {
             String errorReport = s.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(-1);
+                System.exit(Globals.EXITCODE_CONF_ERROR);
             }
         }
     }

--- a/src/main/java/com/github/vaerys/commands/creator/Restart.java
+++ b/src/main/java/com/github/vaerys/commands/creator/Restart.java
@@ -18,7 +18,7 @@ public class Restart implements Command {
         try {
             Thread.sleep(4000);
             Globals.getClient().logout();
-            System.exit(2);
+            System.exit(Globals.EXITCODE_RESTART);
         } catch (DiscordException e) {
             Utility.sendStack(e);
         } catch (InterruptedException e) {

--- a/src/main/java/com/github/vaerys/commands/creator/Restart.java
+++ b/src/main/java/com/github/vaerys/commands/creator/Restart.java
@@ -1,6 +1,7 @@
 package com.github.vaerys.commands.creator;
 
 import com.github.vaerys.commands.CommandObject;
+import com.github.vaerys.main.Constants;
 import com.github.vaerys.main.Globals;
 import com.github.vaerys.main.Utility;
 import com.github.vaerys.templates.Command;
@@ -18,7 +19,7 @@ public class Restart implements Command {
         try {
             Thread.sleep(4000);
             Globals.getClient().logout();
-            System.exit(Globals.EXITCODE_RESTART);
+            System.exit(Constants.EXITCODE_RESTART);
         } catch (DiscordException e) {
             Utility.sendStack(e);
         } catch (InterruptedException e) {

--- a/src/main/java/com/github/vaerys/commands/creator/Shutdown.java
+++ b/src/main/java/com/github/vaerys/commands/creator/Shutdown.java
@@ -18,7 +18,7 @@ public class Shutdown implements Command {
         try {
             Thread.sleep(4000);
             Globals.getClient().logout();
-            System.exit(1);
+            System.exit(Globals.EXITCODE_NORMAL);
         } catch (DiscordException e) {
             Utility.sendStack(e);
         } catch (InterruptedException e) {

--- a/src/main/java/com/github/vaerys/commands/creator/Shutdown.java
+++ b/src/main/java/com/github/vaerys/commands/creator/Shutdown.java
@@ -1,6 +1,7 @@
 package com.github.vaerys.commands.creator;
 
 import com.github.vaerys.commands.CommandObject;
+import com.github.vaerys.main.Constants;
 import com.github.vaerys.main.Globals;
 import com.github.vaerys.main.Utility;
 import com.github.vaerys.templates.Command;
@@ -18,7 +19,7 @@ public class Shutdown implements Command {
         try {
             Thread.sleep(4000);
             Globals.getClient().logout();
-            System.exit(Globals.EXITCODE_NORMAL);
+            System.exit(Constants.EXITCODE_NORMAL);
         } catch (DiscordException e) {
             Utility.sendStack(e);
         } catch (InterruptedException e) {

--- a/src/main/java/com/github/vaerys/guildtoggles/ToggleInit.java
+++ b/src/main/java/com/github/vaerys/guildtoggles/ToggleInit.java
@@ -2,7 +2,7 @@ package com.github.vaerys.guildtoggles;
 
 import com.github.vaerys.guildtoggles.modules.*;
 import com.github.vaerys.guildtoggles.toggles.*;
-import com.github.vaerys.main.Globals;
+import com.github.vaerys.main.Constants;
 import com.github.vaerys.templates.GuildToggle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +75,7 @@ public class ToggleInit {
             String errorReport = t.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(Globals.EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
         }
     }

--- a/src/main/java/com/github/vaerys/guildtoggles/ToggleInit.java
+++ b/src/main/java/com/github/vaerys/guildtoggles/ToggleInit.java
@@ -2,6 +2,7 @@ package com.github.vaerys.guildtoggles;
 
 import com.github.vaerys.guildtoggles.modules.*;
 import com.github.vaerys.guildtoggles.toggles.*;
+import com.github.vaerys.main.Globals;
 import com.github.vaerys.templates.GuildToggle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,7 @@ public class ToggleInit {
             String errorReport = t.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(-1);
+                System.exit(Globals.EXITCODE_CONF_ERROR);
             }
         }
     }

--- a/src/main/java/com/github/vaerys/main/Constants.java
+++ b/src/main/java/com/github/vaerys/main/Constants.java
@@ -32,6 +32,13 @@ public class Constants {
     public static final String ERROR_BRACKETS = "> Brackets `[]` and Parentheses `()` are not required, " +
             "they mean that a variable is required or optional respectively, so don't use them.";
 
+    // constants reperesenting different exit codes
+    public static final short EXITCODE_NORMAL = 0;
+    public static final short EXITCODE_RESTART = 1;
+    public static final short EXITCODE_CONF_ERROR = 2;
+    public static final short EXITCODE_OTHER_ERROR = 3;
+    public static final short EXITCODE_UNKNOWN = 255;
+
 
     public static String getWelcomeMessage(CommandObject object) {
         return "> I am S.A.I.L, your Server-Based Artificial Intelligence Lattice. I help manage servers.\n" +

--- a/src/main/java/com/github/vaerys/main/Globals.java
+++ b/src/main/java/com/github/vaerys/main/Globals.java
@@ -77,6 +77,13 @@ public class Globals {
     private static Events events;
     private static String currentEvent = null;
 
+    // constants reperesenting different exit codes
+    public static final short EXITCODE_NORMAL = 0;
+    public static final short EXITCODE_RESTART = 1;
+    public static final short EXITCODE_CONF_ERROR = 2;
+    public static final short EXITCODE_OTHER_ERROR = 3;
+    public static final short EXITCODE_UNKNOWN = 255;
+
 
     public static void initConfig(IDiscordClient ourClient, Config config, GlobalData newGlobalData) {
         if (newGlobalData != null) {
@@ -166,7 +173,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(-1);
+                System.exit(EXITCODE_CONF_ERROR);
             }
         }
         for (Command c : creatorCommands) {
@@ -174,7 +181,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(-1);
+                System.exit(EXITCODE_CONF_ERROR);
             }
         }
         for (Command c : slashCommands) {
@@ -182,7 +189,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(-1);
+                System.exit(EXITCODE_CONF_ERROR);
             }
         }
         for (GuildToggle g : guildGuildToggles) {

--- a/src/main/java/com/github/vaerys/main/Globals.java
+++ b/src/main/java/com/github/vaerys/main/Globals.java
@@ -77,13 +77,6 @@ public class Globals {
     private static Events events;
     private static String currentEvent = null;
 
-    // constants reperesenting different exit codes
-    public static final short EXITCODE_NORMAL = 0;
-    public static final short EXITCODE_RESTART = 1;
-    public static final short EXITCODE_CONF_ERROR = 2;
-    public static final short EXITCODE_OTHER_ERROR = 3;
-    public static final short EXITCODE_UNKNOWN = 255;
-
 
     public static void initConfig(IDiscordClient ourClient, Config config, GlobalData newGlobalData) {
         if (newGlobalData != null) {
@@ -173,7 +166,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
         }
         for (Command c : creatorCommands) {
@@ -181,7 +174,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
         }
         for (Command c : slashCommands) {
@@ -189,7 +182,7 @@ public class Globals {
             String errorReport = c.validate();
             if (errorReport != null) {
                 logger.error(errorReport);
-                System.exit(EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
         }
         for (GuildToggle g : guildGuildToggles) {

--- a/src/main/java/com/github/vaerys/main/InitEvent.java
+++ b/src/main/java/com/github/vaerys/main/InitEvent.java
@@ -16,7 +16,7 @@ public class InitEvent {
             Globals.validateConfig();
         }catch (Exception e){
             Utility.sendStack(e);
-            System.exit(Globals.EXITCODE_UNKNOWN);
+            System.exit(Constants.EXITCODE_UNKNOWN);
         }
         Globals.setVersion();
 //        if (args.length > 0 && args[0].equals("-w")) {

--- a/src/main/java/com/github/vaerys/main/InitEvent.java
+++ b/src/main/java/com/github/vaerys/main/InitEvent.java
@@ -16,7 +16,7 @@ public class InitEvent {
             Globals.validateConfig();
         }catch (Exception e){
             Utility.sendStack(e);
-            System.exit(-1);
+            System.exit(Globals.EXITCODE_UNKNOWN);
         }
         Globals.setVersion();
 //        if (args.length > 0 && args[0].equals("-w")) {

--- a/src/main/java/com/github/vaerys/main/Main.java
+++ b/src/main/java/com/github/vaerys/main/Main.java
@@ -85,7 +85,7 @@ public class Main {
                 token = FileHandler.readFromFile(Constants.FILE_TOKEN).get(0);
             } catch (IndexOutOfBoundsException e) {
                 logger.error("!!!BOT TOKEN NOT VALID PLEASE CHECK \"Storage/Token.txt\" AND UPDATE THE TOKEN!!!");
-                System.exit(Globals.EXITCODE_CONF_ERROR);
+                System.exit(Constants.EXITCODE_CONF_ERROR);
             }
 
             try {
@@ -169,7 +169,7 @@ public class Main {
         while (scanner.hasNextLine()) {
             String message = scanner.nextLine();
             if (message.equalsIgnoreCase("!Shutdown")){
-                System.exit(Globals.EXITCODE_NORMAL);
+                System.exit(Constants.EXITCODE_NORMAL);
                 return;
             }
             if (Globals.consoleMessageCID != -1) {

--- a/src/main/java/com/github/vaerys/main/Main.java
+++ b/src/main/java/com/github/vaerys/main/Main.java
@@ -85,7 +85,7 @@ public class Main {
                 token = FileHandler.readFromFile(Constants.FILE_TOKEN).get(0);
             } catch (IndexOutOfBoundsException e) {
                 logger.error("!!!BOT TOKEN NOT VALID PLEASE CHECK \"Storage/Token.txt\" AND UPDATE THE TOKEN!!!");
-                System.exit(-1);
+                System.exit(Globals.EXITCODE_CONF_ERROR);
             }
 
             try {
@@ -169,7 +169,7 @@ public class Main {
         while (scanner.hasNextLine()) {
             String message = scanner.nextLine();
             if (message.equalsIgnoreCase("!Shutdown")){
-                System.exit(-1);
+                System.exit(Globals.EXITCODE_NORMAL);
                 return;
             }
             if (Globals.consoleMessageCID != -1) {


### PR DESCRIPTION
I offer for your perusal, SAIL's exit codes reconfigured to follow a more [standardized approach](https://en.wikipedia.org/wiki/Exit_status). Apologies for making the PR to master, I didn't know where else to put it.

Here's a quick explanation of what each field means:

- `EXITCODE_NORMAL = 0`: Used when the program is shut down normally. The "Everything is Okay" alarm, so to speak.
- `EXITCODE_RESTART = 1`: _Normally a non-zero exit code is used to indicate an error,_ but using a number specifically for a builtin restart command allows you to design scripts to start the bot that work with this.
- `EXITCODE_CONF_ERROR = 2`: This exit code is proposed for when the bot reports a configuration error, and that the user should check the bot's log files to find out what went wrong.
- `EXITCODE_OTHER_ERROR = 3`: This is unused at the moment, but it could be used if the bot needs to close for any other anticipated errors.
- `EXITCODE_UNKNOWN = 255`: This one is sort of a fallback, if the program has to crash and a handler can catch it, it should exit with this. Basically, something really went wrong here, and we don't know what.