### PR TITLE
Fix bug with Auto artpinning where it printed the userobject tostring…

### DIFF
--- a/src/main/java/com/github/vaerys/handlers/ArtHandler.java
+++ b/src/main/java/com/github/vaerys/handlers/ArtHandler.java
@@ -129,7 +129,7 @@ public class ArtHandler {
                 }
                 response += " art by reacting with the \uD83D\uDCCC emoji.";
             } else {
-                response = "> I have pinned **" + owner + "'s** art.";
+                response = "> I have pinned **" + owner.displayName + "'s** art.";
             }
             if (command.guild.config.likeArt && command.guild.config.modulePixels) {
                 response += "\nYou can now react with a \u2764 emoji to give the user some pixels.";


### PR DESCRIPTION
… instead of the user's name

- [x] I have made sure that the bot will run with this code.
- [ ] I have tested my code.
- [x] I have followed the [message formatting guidelines](https://github.com/Vaerys-Dawn/DiscordSailv2/wiki/Contributor-Message-Formatting-Guide).

## Patch Notes:
