### PR TITLE
Make SAIL respond better when doing $listchar user

### DIFF
--- a/src/main/java/com/github/vaerys/commands/characters/ListChars.java
+++ b/src/main/java/com/github/vaerys/commands/characters/ListChars.java
@@ -42,7 +42,9 @@ public class ListChars extends Command {
         List<String> list = user.characters.stream().map(c -> c.getName()).collect(Collectors.toList());
         //give message if empty
         if (list.size() == 0) {
-            return "> You do not have any characters yet. Create one with **" + new UpdateChar().getUsage(command) + "**.";
+            return user.longID == command.user.longID ?
+                    "> You do not have any characters yet. Create one with **" + new UpdateChar().getUsage(command) + "**." :
+                    "> User does not have any characters yet.";
         }
         //build embed data
         builder.withTitle(title);


### PR DESCRIPTION
`$listchar [user]` will now say `> User does not have any characters yet.` instead when listing the chars of another user with no characters yet.

- [x] I have made sure that the bot will run with this code.
- [x] I have tested my code.
- [x] I have followed the [message formatting guidelines](https://github.com/Vaerys-Dawn/DiscordSailv2/wiki/Contributor-Message-Formatting-Guide).
