### PR TITLE
Update Custom Command name filter to be more strict.

### DIFF
--- a/src/main/java/com/github/vaerys/commands/cc/NewCC.java
+++ b/src/main/java/com/github/vaerys/commands/cc/NewCC.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.regex.Pattern;
 
 /**
  * Created by Vaerys on 01/02/2017.
@@ -55,8 +56,8 @@ public class NewCC extends Command {
             return "> Custom Commands cannot have the same name as built-in commands.";
         }
 
-        if (nameCC.contains("```")) {
-            return "> Custom Command names cannot contain code blocks";
+        if (!Pattern.matches("[\\p{Alnum}\\p{Punct}&&[^#@$*_\\\\/`]]+", nameCC)) {
+            return "> Custom Command names cannot contain special characters.";
         }
 
         if ((argsCC == null || argsCC.isEmpty()) && command.message.get().getAttachments().size() == 0) {

--- a/src/main/java/com/github/vaerys/commands/cc/NewCC.java
+++ b/src/main/java/com/github/vaerys/commands/cc/NewCC.java
@@ -56,7 +56,7 @@ public class NewCC extends Command {
             return "> Custom Commands cannot have the same name as built-in commands.";
         }
 
-        if (!Pattern.matches("[\\p{Alnum}\\p{Punct}&&[^#@$*_\\\\/`]]+", nameCC)) {
+        if (!Pattern.matches("[\\p{Alnum}\\p{Punct}&&[^#@$*\\\\/`]]+", nameCC)) {
             return "> Custom Command names cannot contain special characters.";
         }
 


### PR DESCRIPTION
- [x] I have made sure that the bot will run with this code.
- [x] I have tested my code.
- [x] I have followed the [message formatting guidelines](https://github.com/Vaerys-Dawn/DiscordSailv2/wiki/Contributor-Message-Formatting-Guide).

## Patch Notes:
CC name filtering is more aggressive.
(Now only allows names that match the following pattern:
```[\\p{Alnum}\\p{Punct}&&[^#@$*\\\\/`]]+```