### PR TITLE
Check message limit when sending Embeds.

### DIFF
--- a/src/main/java/com/github/vaerys/handlers/RequestHandler.java
+++ b/src/main/java/com/github/vaerys/handlers/RequestHandler.java
@@ -93,6 +93,13 @@ public class RequestHandler {
             String checkedMessage = message;
             if (builder == null) throw new IllegalArgumentException("Embed builder must never be null.");
             if (checkedMessage == null) checkedMessage = "";
+            if (checkedMessage.length() > 2000) {
+                StringHandler error = new StringHandler("> Could not send message, Too large. ")
+                        .append("Please contact my developer by sending me a **Direct Message** with the **Command Name** that caused this message.");
+                sendMessage(error.toString(), channel);
+                sendError("Could not send message, Too Large.", message, channel);
+                return null;
+            }
             EmbedObject embed = builder.build();
             try {
                 return channel.sendMessage(checkedMessage, embed);


### PR DESCRIPTION
Would now check message content length when sending embeds, and respond accordingly if it exceeds the character limit.

- [x] I have made sure that the bot will run with this code.
- [x] I have tested my code.
- [x] I have followed the [message formatting guidelines](https://github.com/Vaerys-Dawn/DiscordSailv2/wiki/Contributor-Message-Formatting-Guide).

## Patch Notes:
Is the `Please contact my developer by sending me a **Direct Message** with the **Command Name** that caused this message.` response still needed? (Because reaching message limits is usually caused by lengthy command arguments, rarely something else.)